### PR TITLE
implementing trickleback changes and updating to data release 1.1

### DIFF
--- a/DATA_RELEASE_NOTES.md
+++ b/DATA_RELEASE_NOTES.md
@@ -1,0 +1,56 @@
+# Release notes for the *IAMC 1.5°C Scenario Explorer and Data hosted by IIASA*
+
+This document keeps track of the data changes of the scenario ensemble
+compiled in the *IAMC 1.5°C Scenario Explorer and Data hosted by IIASA*.
+
+
+## Release 1.1
+
+This release includes additional timeseries data to increase reproducibility
+of the figures and tables in the IPCC SR15, and it corrects a number of
+data issues identified since Release 1.0. None of the changes have
+any impact on the assessment in the IPCC SR15.
+
+### Detailed list of changes
+
+ - Reporting error for primary energy from fossils (aggregate) submitted by
+   the 'MESSAGE-GLOBIOM 1.0' scenarios as part of the 'EMF33' project.
+   See [#1](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/1)
+   for details.
+
+ - Typo in a variable name and incorrect values in two timeseries of 
+   the reference data from 'IEA Statistics' included in the release.
+   See [#2](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/2)
+   for details.
+
+ - Missing subsectoral CO2 emissions for scenarios from the SSP, CD-LINKS
+   and LED projects.
+   See [#3](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/3)
+   and [#4](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/4)
+   for details.
+
+ - Missing timeseries of harmonized emissions as used for climate impact
+   assessment by the MAGICC and FAIR models.
+   See [#5](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/5)
+   for details.
+
+ - Error in index year for the variable 'Price|Agriculture|*' in scenarios
+   submitted by the 'AIM' model.
+   See [#7](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/7)
+   for details.
+
+ - Missing value for cumulative BECCS in the metadata for
+   the 'LowEnergyDemand' scenario submitted by the 'MESSAGEix-GLOBIOM' model.
+   See [#9](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/9)
+   for details.
+
+ - Incorrect regional data (other than 'World') for scenario submitted
+   by the 'POLES' model as part ofthe 'EMF33' project.
+   See [#12](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/12)
+   for details.
+
+
+## Release 1.0
+
+Scenario ensemble release for the soft launch of the IPCC SR15
+following the approval plenary in Incheon, Republic of Korea.

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@
 
 ## License
 
-Copyright 2018 IIASA
+Copyright 2018-2019 IIASA
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## License
 
-Copyright 2018 IIASA
+Copyright 2018-2019 IIASA
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ publication of the final, copy-edited version of the SR1.5
 The scenario ensemble used for this assessment is available for download
 at [data.ene.iiasa.ac.at/iamc-1.5c-explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer).
 
-The scenario data is licensed under a derivative of the Creative Commons CC-BY 4.0 License.
+The scenario data is released under a custom license.
 If appropriate reference is made to the data source, it is permitted to use
 the data for scientific research and science communication.
 However, redistribution of substantial portions of the data is restricted.

--- a/assessment/spm_sr15_figure_3a_global_emissions_pathways.ipynb
+++ b/assessment/spm_sr15_figure_3a_global_emissions_pathways.ipynb
@@ -16,7 +16,12 @@
     "This notebook extracts the emissions pathways for Figure 3a in the Summary for Policymakers\n",
     "of the IPCC's _\"Special Report on Global Warming of 1.5°C\"_.\n",
     "\n",
-    "The scenario data used in this analysis can be accessed and downloaded at [https://data.ene.iiasa.ac.at/iamc-1.5c-explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer)."
+    "The scenario data used in this analysis can be accessed and downloaded at [https://data.ene.iiasa.ac.at/iamc-1.5c-explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer).\n",
+    "\n",
+    "### *Disclaimer*\n",
+    "\n",
+    "*The figures shown in this notebook are NOT the same figures as used in Figure 3a of the SPM.\n",
+    "They are simplified figures included here only for reference.*"
    ]
   },
   {
@@ -84,8 +89,12 @@
     "with open(\"sr15_specs.yaml\", 'r') as stream:\n",
     "    specs = yaml.load(stream)\n",
     "\n",
+    "rc = pyam.run_control()\n",
+    "for item in specs.pop('run_control').items():\n",
+    "    rc.update({item[0]: item[1]})\n",
     "cats = specs.pop('cats')\n",
     "cats_15 = specs.pop('cats_15')\n",
+    "cats_15_no_lo = specs.pop('cats_15_no_lo')\n",
     "marker= specs.pop('marker')"
    ]
   },
@@ -117,6 +126,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.set_meta(meta='1.5C limited overshoot', name='supercategory', index=df.filter(category=cats_15_no_lo))\n",
+    "rc.update({'color': {'supercategory': {'1.5C limited overshoot': 'xkcd:bluish'}}})"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -145,16 +164,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot different emissions pathways by category"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "writer = pd.ExcelWriter('output/spm_sr15_figure3a_data_table.xlsx')"
+    "## Plot different emissions pathways by category\n",
+    "\n",
+    "### Net carbon dioxide emissions for all pathways limiting global warming to 1.5°C by the end of the century"
    ]
   },
   {
@@ -166,11 +178,8 @@
     "co2 = (\n",
     "    df.filter(variable='Emissions|CO2')\n",
     "    .convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)})\n",
-    "    .timeseries()\n",
     ")\n",
-    "\n",
-    "pyam.utils.write_sheet(writer, 'Net CO2',\n",
-    "                       pyam.filter_by_meta(co2, **filter_args), index=True)"
+    "data.append(('Net carbon dioxide', co2))"
    ]
   },
   {
@@ -179,9 +188,60 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ch4 = df.filter(variable='Emissions|CH4').timeseries()\n",
-    "pyam.utils.write_sheet(writer, 'CH4',\n",
-    "                       pyam.filter_by_meta(ch4, **filter_args), index=True)"
+    "_co2 = co2.filter(category=cats_15, year=range(2010, 2101, 5))\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "_co2.filter(year=[2010]).line_plot(ax=ax, color='category', linewidth=2)\n",
+    "_co2.line_plot(ax=ax, color='category', linewidth=0.1, fill_between=True, final_ranges=True)\n",
+    "_co2.filter(marker=marker).line_plot(ax=ax, color='category')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Emissions of methane, black carbon and nitrous oxide for 1.5°C pathways with limited overshoot\n",
+    "\n",
+    "The figures below are shown as reduction relative to 2010."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_relative(data, baseyear=2010):\n",
+    "    _data = data.timeseries()\n",
+    "    _data_rel = pd.DataFrame()\n",
+    "    for y in range(2010, 2101, 5):\n",
+    "        _data_rel[y] = _data[y] / _data[2010]\n",
+    "\n",
+    "    _data_rel.reset_index(inplace=True)\n",
+    "    _data_rel['unit'] = 'relative to {}'.format(baseyear)\n",
+    "    _df = pyam.IamDataFrame(_data_rel)\n",
+    "    _df.set_meta(meta='1.5C limited overshoot', name='supercategory')\n",
+    "    _df.filter(supercategory='1.5C limited overshoot', year=range(2010, 2101, 5))\\\n",
+    "        .line_plot(color='supercategory', linewidth=0.1, fill_between=True, legend=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ch4 = df.filter(variable='Emissions|CH4')\n",
+    "data.append(('Methane', ch4))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_relative(ch4)"
    ]
   },
   {
@@ -191,8 +251,7 @@
    "outputs": [],
    "source": [
     "bc = df.filter(variable='Emissions|BC')\n",
-    "pyam.utils.write_sheet(writer, 'Black carbon',\n",
-    "                       pyam.filter_by_meta(bc.timeseries(), **filter_args), index=True)"
+    "data.append(('Black carbon', bc))"
    ]
   },
   {
@@ -201,9 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n2o = df.filter(variable='Emissions|N2O').timeseries()\n",
-    "pyam.utils.write_sheet(writer, 'N2O',\n",
-    "                       pyam.filter_by_meta(n2o, **filter_args), index=True)"
+    "plot_relative(bc)"
    ]
   },
   {
@@ -212,9 +269,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fgases = df.filter(variable='Emissions|F-Gases').timeseries()\n",
-    "pyam.utils.write_sheet(writer, 'F-Gases',\n",
-    "                       pyam.filter_by_meta(fgases, **filter_args), index=True)"
+    "n2o = df.filter(variable='Emissions|N2O')\n",
+    "n2o.convert_unit({'kt N2O/yr': ('Mt N2O/yr', 0.001)}, inplace=True)\n",
+    "data.append(('Nitrous oxide', n2o))"
    ]
   },
   {
@@ -223,9 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "so2 = df.filter(variable='Emissions|Sulfur').timeseries()\n",
-    "pyam.utils.write_sheet(writer, 'Sulfur',\n",
-    "                       pyam.filter_by_meta(so2, **filter_args), index=True)"
+    "plot_relative(n2o)"
    ]
   },
   {
@@ -241,6 +296,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "writer = pd.ExcelWriter('output/spm_sr15_figure3a_data_table.xlsx')\n",
+    "for (name, _df) in data:\n",
+    "    pyam.utils.write_sheet(writer, name,\n",
+    "                           pyam.filter_by_meta(_df.timeseries(), **filter_args), index=True)\n",
     "writer.save()"
    ]
   },

--- a/assessment/spm_sr15_figure_3a_global_emissions_pathways.ipynb
+++ b/assessment/spm_sr15_figure_3a_global_emissions_pathways.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
+++ b/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
+++ b/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
@@ -356,7 +356,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Land cover for energy crops"
+    "### Land cover for energy crops\n",
+    "\n",
+    "Convert unit to SI unit (million square kilometers)."
    ]
   },
   {
@@ -365,7 +367,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "energy_crops = df.filter(variable='Land Cover|Cropland|Energy Crops', year=2050).timeseries()"
+    "energy_crops = (\n",
+    "    df.filter(variable='Land Cover|Cropland|Energy Crops', year=2050)\n",
+    "    .convert_unit({'million ha': ('million km2', 0.01)})\n",
+    "    .timeseries()\n",
+    ")"
    ]
   },
   {
@@ -374,7 +380,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats.add(energy_crops[2050], header='Land are for energy crops (MHa)')"
+    "stats.add(energy_crops[2050], header='Land are for energy crops (million km2)')"
    ]
   },
   {

--- a/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
+++ b/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
@@ -160,7 +160,7 @@
    "outputs": [],
    "source": [
     "co2 = (\n",
-    "    df.filter(variable='Emissions|CO2', year=years)\n",
+    "    df.filter(kyoto_ghg_2010='in range', variable='Emissions|CO2', year=years)\n",
     "    .convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)})\n",
     "    .timeseries()\n",
     ")"
@@ -185,7 +185,7 @@
    "outputs": [],
    "source": [
     "kyoto_ghg = (\n",
-    "    df.filter(variable='Emissions|Kyoto Gases (SAR-GWP100)', year=years)\n",
+    "    df.filter(kyoto_ghg_2010='in range', variable='Emissions|Kyoto Gases (SAR-GWP100)', year=years)\n",
     "    .convert_unit({'Mt CO2-equiv/yr': ('Gt CO2-equiv/yr', 0.001)})\n",
     "    .timeseries()\n",
     ")\n",
@@ -400,7 +400,7 @@
    "outputs": [],
    "source": [
     "for n in species:\n",
-    "    data = df.filter(variable='Emissions|{}|AFOLU'.format(n), year=years).timeseries()\n",
+    "    data = df.filter(kyoto_ghg_2010='in range', variable='Emissions|{}|AFOLU'.format(n), year=years).timeseries()\n",
     "\n",
     "    for y in compare_years:\n",
     "        stats.add((data[y] / data[base_year] - 1) * 100,\n",

--- a/assessment/spm_sr15_statements.ipynb
+++ b/assessment/spm_sr15_statements.ipynb
@@ -626,14 +626,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats_d11.summarize(fullrange=True, custom_format='{:.1f}')"
+    "stats_d11.summarize(interquartile=True, custom_format='{:.1f}')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Show pathways that limit warming to 1.5 with no or low overshoot that exceed the threshold of 35Gt CO2-eq/yr in 2030."
+    "## Checking 1.5°C pathways with limited overshoot that do not reduce CO2 emissions to below 35Gt in 2030"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ghg_ar4 = (\n",
+    "    df.filter(variable='Emissions|Kyoto Gases (AR4-GWP100)')\n",
+    "    .convert_unit({'Mt CO2-equiv/yr': ('Gt CO2-equiv/yr', 0.001)})\n",
+    "    .timeseries()\n",
+    ")"
    ]
   },
   {
@@ -656,7 +669,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/assessment/spm_sr15_statements.ipynb
+++ b/assessment/spm_sr15_statements.ipynb
@@ -145,7 +145,7 @@
    "outputs": [],
    "source": [
     "filters_15_no_lo = [('no & lo os 1.5', {'category': cats_15_no_lo})]\n",
-    "filters_compare = filters_15_no_lo + [('2.0', {'category': cats_2})]"
+    "filters_compare = filters_15_no_lo + [('2.0 lo', {'category': 'Lower 2C'})]"
    ]
   },
   {

--- a/assessment/spm_sr15_statements.ipynb
+++ b/assessment/spm_sr15_statements.ipynb
@@ -618,8 +618,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ghg_ar4 = (\n",
-    "    df.filter(variable='Emissions|Kyoto Gases (AR4-GWP100)')\n",
+    "ghg_ar4_sar = (\n",
+    "    df.filter(kyoto_ghg_2010='in range', variable='Emissions|Kyoto Gases (AR4-GWP100)')\n",
     "    .convert_unit({'Mt CO2-equiv/yr': ('Gt CO2-equiv/yr', 0.001)})\n",
     "    .timeseries()\n",
     ")"
@@ -631,7 +631,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats_d11.add(ghg_ar4[[compare_year, 2030]], header='Kyoto GHG emissions (Gt CO2-eq/yr)')"
+    "stats_d11.add(ghg_ar4_sar[[compare_year, 2030]], header='Kyoto GHG emissions (Gt CO2-eq/yr)')"
    ]
   },
   {
@@ -640,7 +640,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats_d11.add((ghg_ar4[2030] / ghg_ar4[compare_year] - 1) * 100,\n",
+    "stats_d11.add((ghg_ar4_sar[2030] / ghg_ar4_sar[compare_year] - 1) * 100,\n",
     "              header='Reduction of Kyoto GHG emissions',\n",
     "              subheader='2030 relative to {} (%)'.format(compare_year))"
    ]

--- a/assessment/spm_sr15_statements.ipynb
+++ b/assessment/spm_sr15_statements.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/spm_sr15_statements.ipynb
+++ b/assessment/spm_sr15_statements.ipynb
@@ -565,61 +565,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Statement C3.2: Carbon capture and sequestration"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stats_c32 = pyam.Statistics(df=df, filters=filters_15_no_lo, rows=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "beccs = (\n",
-    "    df.filter(variable='Carbon Sequestration|CCS|Biomass', year=[2030, 2050, 2100])\n",
-    "    .convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)})\n",
-    "    .timeseries()\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stats_c32.add(beccs, header='Deployment of CDR', row='BECCS')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stats_c32.summarize(fullrange=True, custom_format='{:.0f}')"
+    "## Statement C3.2: Carbon capture and sequestration\n",
+    "\n",
+    "Please refer to the notebook [sr15_2.3.4_carbon_dioxide_removal](sr1p5_2.3.4_carbon_dioxide_removal.ipynb) in this folder\n",
+    "for the detailed assessment."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please refer to the notebook [sr15_2.3.4_carbon_dioxide_removal](sr1p5_2.3.4_carbon_dioxide_removal.ipynb) in this folder for the additional assessment."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Statement D1.1: CO2 emissions reductions"
+    "## Statement D1.1: CO2 emissions reductions"
    ]
   },
   {

--- a/assessment/spm_sr15_statements.ipynb
+++ b/assessment/spm_sr15_statements.ipynb
@@ -152,7 +152,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Statement C1: Net CO2 emissions by warming categories and year of crossing the net-zero threshold"
+    "## Statement C1: Net CO2 emissions by warming categories and year of crossing the net-zero threshold\n",
+    "\n",
+    "To reduce potential bias by many scenarios from the same modelling framework, 13 scenarios submitted by the 'AIM' model are excluded from the assessment underpinning this statement (cf. Table 2.4)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter_args_aim = dict(model='AIM*',\n",
+    "                       scenario=['SFCM*_1p5Degree', 'EMF33_Med2C_nofuel', 'EMF33_Med2C_none'],\n",
+    "                       keep=False)"
    ]
   },
   {
@@ -170,9 +183,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "co2 = df.filter(kyoto_ghg_2010='in range', variable='Emissions|CO2')\n",
-    "co2.convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)}, inplace=True)\n",
-    "co2 = co2.timeseries()"
+    "co2 = (\n",
+    "    df.filter(kyoto_ghg_2010='in range', variable='Emissions|CO2')\n",
+    "    .filter(**filter_args_aim)\n",
+    "    .convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)})\n",
+    "    .timeseries()\n",
+    ")"
    ]
   },
   {
@@ -201,7 +217,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "net_zero = df.filter(kyoto_ghg_2010='in range').meta['year of netzero CO2 emissions']\n",
+    "net_zero = (\n",
+    "    df.filter(kyoto_ghg_2010='in range')\n",
+    "    .filter(**filter_args_aim)\n",
+    ").meta['year of netzero CO2 emissions']\n",
     "netzero = net_zero[net_zero < 2100]"
    ]
   },
@@ -211,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats_c1.add(netzero,\n",
+    "stats_c1.add(net_zero,\n",
     "             header='Year of net-zero'.format(y),\n",
     "             subheader=''.format(compare_year),\n",
     "             row='Net CO2 emissions')"

--- a/assessment/sr15_2.0_categories_indicators.ipynb
+++ b/assessment/sr15_2.0_categories_indicators.ipynb
@@ -68,8 +68,8 @@
     "([https://software.ene.iiasa.ac.at/pyam/](http://software.ene.iiasa.ac.at/pyam/)).\n",
     "\n",
     "For an introduction of the notation and features of the `pyam` package,\n",
-    "please refer to [github.com/IAMconsortium/pyam/tutorial/pyam_first_steps](https://github.com/IAMconsortium/pyam/blob/master/tutorial/pyam_first_steps.ipynb).  \n",
-    "The tutorial will take you through the basic functions and options used here,\n",
+    "please refer to [this tutorial](https://github.com/IAMconsortium/pyam/blob/master/doc/source/tutorials/pyam_first_steps.ipynb).  \n",
+    "It will take you through the basic functions and options used here,\n",
     "and provide further introduction and guidelines."
    ]
   },
@@ -1530,10 +1530,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = 'cumulative CCS ({}-{}, {})'.format(baseyear, lastyear, cumulative_unit)\n",
-    "sr1p5.set_meta(ccs.apply(pyam.cumulative, raw=False, axis=1, first_year=baseyear, last_year=lastyear), name)\n",
-    "meta_docs[name] = 'Cumulative carbon capture and sequestration from {} until {} (including the last year, {})'.format(\n",
-    "    baseyear, lastyear, cumulative_unit)"
+    "cum_ccs_label = 'cumulative CCS ({}-{}, {})'.format(baseyear, lastyear, cumulative_unit)\n",
+    "sr1p5.set_meta(ccs.apply(pyam.cumulative, raw=False, axis=1, first_year=baseyear, last_year=lastyear), cum_ccs_label)\n",
+    "meta_docs[cum_ccs_label] = 'Cumulative carbon capture and sequestration from {} until {} (including the last year, {})'\\\n",
+    "    .format(baseyear, lastyear, cumulative_unit)"
    ]
   },
   {
@@ -1551,10 +1551,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = 'cumulative BECCS ({}-{}, {})'.format(baseyear, lastyear, cumulative_unit)\n",
-    "sr1p5.set_meta(beccs.apply(pyam.cumulative, raw=False, axis=1, first_year=baseyear, last_year=lastyear), name)\n",
-    "meta_docs[name] = 'Cumulative carbon capture and sequestration from bioenergy from {} until {} (including the last year, {})'.format(\n",
+    "cum_beccs_label = 'cumulative BECCS ({}-{}, {})'.format(baseyear, lastyear, cumulative_unit)\n",
+    "sr1p5.set_meta(beccs.apply(pyam.cumulative, raw=False, axis=1, first_year=baseyear, last_year=lastyear), cum_beccs_label)\n",
+    "meta_docs[cum_beccs_label] = 'Cumulative carbon capture and sequestration from bioenergy from {} until {} (including the last year, {})'.format(\n",
     "    baseyear, lastyear, cumulative_unit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Issue [#9](https://github.com/iiasa/ipcc_sr15_scenario_analysis/issues/9) requested to add the data for scenario where timeseries data for bioenergy with CCS was not provided explicitly (and hence not captured by the computation above) but could implicitly by assessed from the CCS timeseries data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filled_ccs = sr1p5.meta[sr1p5.meta[cum_ccs_label] == 0][cum_beccs_label]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sr1p5.set_meta(name=cum_beccs_label, meta=0, index=filled_ccs[filled_ccs.isna()].index)"
    ]
   },
   {

--- a/assessment/sr15_2.0_categories_indicators.ipynb
+++ b/assessment/sr15_2.0_categories_indicators.ipynb
@@ -1142,16 +1142,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO make this nicer or remove\n",
-    "sr1p5.meta.groupby(['project', 'category']).count()['reference'].unstack().reindex(columns=all_cats)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/assessment/sr15_2.0_categories_indicators.ipynb
+++ b/assessment/sr15_2.0_categories_indicators.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.3.1_range_of_assumptions.ipynb
+++ b/assessment/sr15_2.3.1_range_of_assumptions.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.3.3_global_emissions_characteristics.ipynb
+++ b/assessment/sr15_2.3.3_global_emissions_characteristics.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.3.3_global_emissions_statistics.ipynb
+++ b/assessment/sr15_2.3.3_global_emissions_statistics.ipynb
@@ -92,7 +92,9 @@
    "source": [
     "## Downselect scenario ensemble to categories of interest for this assessment\n",
     "\n",
-    "Apply the filter by relevant years *after computing the year of netzero*."
+    "To reduce potential bias by many scenarios from the same modelling framework, 13 scenarios submitted by the 'AIM' model are excluded from the assessment underpinning this statement (cf. SPM Statement C1).\n",
+    "\n",
+    "Also, note that we apply the filter by relevant years *after computing the year of netzero*."
    ]
   },
   {
@@ -119,7 +121,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = sr1p5.filter(kyoto_ghg_2010='in range', category=cats)"
+    "filter_args_aim = dict(model='AIM*',\n",
+    "                       scenario=['SFCM*_1p5Degree', 'EMF33_Med2C_nofuel', 'EMF33_Med2C_none'],\n",
+    "                       keep=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = (\n",
+    "    sr1p5\n",
+    "    .filter(kyoto_ghg_2010='in range', category=cats)\n",
+    "    .filter(**filter_args_aim)\n",
+    ")"
    ]
   },
   {

--- a/assessment/sr15_2.3.3_global_emissions_statistics.ipynb
+++ b/assessment/sr15_2.3.3_global_emissions_statistics.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.3.3_global_emissions_statistics.ipynb
+++ b/assessment/sr15_2.3.3_global_emissions_statistics.ipynb
@@ -83,7 +83,7 @@
     "for item in specs.pop('run_control').items():\n",
     "    rc.update({item[0]: item[1]})\n",
     "cats = specs.pop('cats')\n",
-    "marker= specs.pop('marker')"
+    "cats_15_no_lo = specs.pop('cats_15_no_lo')"
    ]
   },
   {
@@ -152,7 +152,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats = pyam.Statistics(df=df, groupby={'category': cats}, rows=True)"
+    "stats = pyam.Statistics(df=df,\n",
+    "                        filters=[\n",
+    "                            ('below 1.5', {'category': 'Below 1.5C'}),\n",
+    "                            ('lo os 1.5', {'category': '1.5C low overshoot'}),\n",
+    "                            ('no & lo os 1.5', {'category': cats_15_no_lo}),\n",
+    "                            ('hi os 1.5', {'category': ['1.5C high overshoot']}),\n",
+    "                            ('lower 2.0', {'category': ['Lower 2C']}),\n",
+    "                            ('higher 2.0', {'category': ['Higher 2C']})]\n",
+    "                        , rows=True)"
    ]
   },
   {
@@ -408,7 +416,7 @@
    "source": [
     "## Display and export summary statistics to `xlsx`\n",
     "\n",
-    "Note that in Table 2.4 as printed in the pre-release of the Special Report following the approval plenary, the full range if shown for any cells with less than 7 scenarios, and interquartile ranges are shown otherwise.\n",
+    "Note that in Table 2.4 as printed in the Special Report, the full range is shown for any cells with less than 7 scenarios, and interquartile ranges are shown otherwise.\n",
     "This formatting was implemented manually ex-post, as it is currently not supported by the `pyam.Statistics` module."
    ]
   },
@@ -418,7 +426,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "summary = stats.summarize(center='median', interquartile=True)\n",
+    "summary = stats.summarize(center='median', interquartile=True, custom_format='{:.1f}')\n",
+    "index = summary.index.get_level_values(1).unique()\n",
+    "summary = (\n",
+    "    summary\n",
+    "    .swaplevel(0, 1, axis=0)\n",
+    "    .reindex(index=index, level=0)\n",
+    ")\n",
     "summary"
    ]
   },

--- a/assessment/sr15_2.3.3_short-lived_climate_forcers.ipynb
+++ b/assessment/sr15_2.3.3_short-lived_climate_forcers.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.3.3_short-lived_climate_forcers_radiative_forcing.ipynb
+++ b/assessment/sr15_2.3.3_short-lived_climate_forcers_radiative_forcing.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.3.4_carbon_dioxide_removal.ipynb
+++ b/assessment/sr15_2.3.4_carbon_dioxide_removal.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.1_final_energy.ipynb
+++ b/assessment/sr15_2.4.1_final_energy.ipynb
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set specifications for filter and plotting"
+    "## Set specifications for filter and plotting and initialize a data list"
    ]
   },
   {
@@ -167,6 +167,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = []"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -190,9 +199,18 @@
    "outputs": [],
    "source": [
     "name = 'final_energy'\n",
-    "boxplot_by_cat(pyam.filter_by_meta(fe, **filter_args),\n",
-    "               **plotting_args('a_{}'.format(name)),\n",
+    "_fe = pyam.filter_by_meta(df.filter(variable='Final Energy').timeseries(), **filter_args)\n",
+    "boxplot_by_cat(_fe, **plotting_args('a_{}'.format(name)),\n",
     "               ylabel='Final Energy (EJ)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.append(('Final energy', _fe))"
    ]
   },
   {
@@ -218,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fe_ele_share = fe_ele / fe * 100"
+    "fe_ele_share = pyam.filter_by_meta(fe_ele / fe * 100, **filter_args)"
    ]
   },
   {
@@ -228,16 +246,24 @@
    "outputs": [],
    "source": [
     "name = 'ele_share'\n",
-    "boxplot_by_cat(pyam.filter_by_meta(fe_ele_share, **filter_args),\n",
-    "               **plotting_args('b_{}'.format(name)), legend=False,\n",
+    "boxplot_by_cat(fe_ele_share, **plotting_args('c_{}'.format(name)), legend=False,\n",
     "               ylabel='Electricity share in Final Energy (%)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.append(('Electricity share', fe_ele_share))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot the development of the carbon intensity of eletricity vs. the residual energy demand"
+    "## Plot the development of the carbon intensity of electricity vs. the residual energy demand"
    ]
   },
   {
@@ -266,18 +292,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "carbon_intensity_ele = co2_ele / fe_ele"
+    "carbon_intensity_ele = pyam.filter_by_meta(co2_ele / fe_ele, **filter_args)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "name = 'carbon_intensity_electricity'\n",
-    "boxplot_by_cat(pyam.filter_by_meta(carbon_intensity_ele, **filter_args),\n",
-    "               **plotting_args('c_{}'.format(name), hlines=[0]), legend=False,\n",
+    "boxplot_by_cat(carbon_intensity_ele, **plotting_args('b_{}'.format(name), hlines=[0]), legend=False,\n",
     "               ylabel='Carbon intensity of electricity (gCO2/MJ)')"
    ]
   },
@@ -287,7 +314,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "carbon_intensity_residual = (co2 - co2_ele) / (fe - fe_ele)"
+    "data.append(('Carbon intensity of electricity', carbon_intensity_ele))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "carbon_intensity_residual = pyam.filter_by_meta((co2 - co2_ele) / (fe - fe_ele), **filter_args)"
    ]
   },
   {
@@ -297,9 +333,36 @@
    "outputs": [],
    "source": [
     "name = 'carbon_intensity_residual'\n",
-    "boxplot_by_cat(pyam.filter_by_meta(carbon_intensity_residual, **filter_args),\n",
-    "               **plotting_args('d_{}'.format(name), hlines=[0]), legend=False,\n",
+    "boxplot_by_cat(carbon_intensity_residual, **plotting_args('d_{}'.format(name), hlines=[0]), legend=False,\n",
     "               ylabel='Carbon intensity of residual fuel mix (gCO2/MJ)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.append(('Carbon intensity of residual', carbon_intensity_residual))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export timeseries data to `xlsx`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writer = pd.ExcelWriter('output/fig2.14_data_table.xlsx')\n",
+    "for (name, _df) in data:\n",
+    "    pyam.utils.write_sheet(writer, name, _df, index=True)\n",
+    "writer.save()"
    ]
   },
   {

--- a/assessment/sr15_2.4.1_final_energy.ipynb
+++ b/assessment/sr15_2.4.1_final_energy.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.2.1_primary_energy_marker-scenarios.ipynb
+++ b/assessment/sr15_2.4.2.1_primary_energy_marker-scenarios.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.2.1_primary_energy_marker-scenarios.ipynb
+++ b/assessment/sr15_2.4.2.1_primary_energy_marker-scenarios.ipynb
@@ -87,9 +87,7 @@
     "for item in specs.pop('run_control').items():\n",
     "    rc.update({item[0]: item[1]})\n",
     "cats = specs.pop('cats')\n",
-    "all_cats = specs.pop('all_cats')\n",
-    "subcats = specs.pop('subcats')\n",
-    "all_subcats = specs.pop('all_subcats')\n",
+    "cats_15_no_lo = specs.pop('cats_15_no_lo')\n",
     "marker = specs.pop('marker')"
    ]
   },
@@ -400,7 +398,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot energy system development by fuel for all 1.5°C and 2°C pathways"
+    "## Plot energy system development by fuel for all 1.5°C pathways with limited overshoot"
    ]
   },
   {
@@ -426,11 +424,11 @@
     "\n",
     "for i, v in enumerate(variables):\n",
     "    _df = df.filter(variable=v).timeseries()\n",
-    "    _df.index = _df.index.droplevel([2, 3, 4])\n",
-    "    _df = pyam.filter_by_meta(_df, df, marker=None, join_meta=True)\n",
+    "    _df = pyam.filter_by_meta(_df, df, category=None, marker=None, join_meta=True)\n",
     "    \n",
     "    for j, y in enumerate(years):\n",
-    "        lst = _df[y][~np.isnan(_df[y])]\n",
+    "        _df_15 = _df[_df.category.isin(cats_15_no_lo)]\n",
+    "        lst = _df_15[y][~np.isnan(_df[y])]\n",
     "        pos = 0.5 / _years * (j - _years / 2) + i\n",
     "        \n",
     "        outliers = len(lst[lst > ymax])\n",

--- a/assessment/sr15_2.4.2.1_primary_energy_marker-scenarios.ipynb
+++ b/assessment/sr15_2.4.2.1_primary_energy_marker-scenarios.ipynb
@@ -480,6 +480,26 @@
     "\n",
     "fig.savefig(save_name.format('b_primary_energy_by_fuel'))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export timeseries data to `xlsx`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writer = pd.ExcelWriter('output/fig2.15_data_table.xlsx')\n",
+    "pyam.utils.write_sheet(writer, name, \n",
+    "                       pyam.filter_by_meta(df.timeseries(), df, category=None, marker=None, join_meta=True),\n",
+    "                       index=True)\n",
+    "writer.save()"
+   ]
   }
  ],
  "metadata": {

--- a/assessment/sr15_2.4.2.1_primary_energy_statistics.ipynb
+++ b/assessment/sr15_2.4.2.1_primary_energy_statistics.ipynb
@@ -131,7 +131,7 @@
    "source": [
     "stats = pyam.Statistics(df=df,\n",
     "                        filters=[('all 1.5', {}),\n",
-    "                                 ('no/lo os 1.5', {'category': cats_15_no_lo}),\n",
+    "                                 ('no & lo os 1.5', {'category': cats_15_no_lo}),\n",
     "                                 ('hi os 1.5', {'category': ['1.5C high overshoot']})\n",
     "                                ], rows=True)"
    ]
@@ -392,7 +392,7 @@
    "outputs": [],
    "source": [
     "fossil = (\n",
-    "    df.filter(variable=['Primary Energy|Fossil'])\n",
+    "    df.filter(variable=['Primary Energy|Coal', 'Primary Energy|Gas', 'Primary Energy|Oil'])\n",
     "    .timeseries()\n",
     "    .groupby(['model', 'scenario']).sum()\n",
     ")"

--- a/assessment/sr15_2.4.2.1_primary_energy_statistics.ipynb
+++ b/assessment/sr15_2.4.2.1_primary_energy_statistics.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.2.2_electricity_generation_marker-scenarios.ipynb
+++ b/assessment/sr15_2.4.2.2_electricity_generation_marker-scenarios.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.2.2_electricity_generation_marker-scenarios.ipynb
+++ b/assessment/sr15_2.4.2.2_electricity_generation_marker-scenarios.ipynb
@@ -87,9 +87,7 @@
     "for item in specs.pop('run_control').items():\n",
     "    rc.update({item[0]: item[1]})\n",
     "cats = specs.pop('cats')\n",
-    "all_cats = specs.pop('all_cats')\n",
-    "subcats = specs.pop('subcats')\n",
-    "all_subcats = specs.pop('all_subcats')\n",
+    "cats_15_no_lo = specs.pop('cats_15_no_lo')\n",
     "marker = specs.pop('marker')"
    ]
   },
@@ -379,7 +377,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot electricity system development by fuel for all 1.5°C and 2°C pathways"
+    "## Plot energy system development by fuel for all 1.5°C pathways with limited overshoot"
    ]
   },
   {
@@ -390,7 +388,7 @@
    "source": [
     "w, h = plt.figaspect(0.3)\n",
     "fig = plt.figure(figsize=(w, h))\n",
-    "ymax = 320\n",
+    "ymax = 220\n",
     "hist_yr = 2015\n",
     "\n",
     "_years = len(years) - 1\n",
@@ -405,11 +403,11 @@
     "\n",
     "for i, v in enumerate(variables):\n",
     "    _df = df.filter(variable=v).timeseries()\n",
-    "    _df.index = _df.index.droplevel([2, 3, 4])\n",
-    "    _df = pyam.filter_by_meta(_df, df, marker=None, join_meta=True)\n",
+    "    _df = pyam.filter_by_meta(_df, df, category=None, marker=None, join_meta=True)\n",
     "    \n",
     "    for j, y in enumerate(years):\n",
-    "        lst = _df[y][~np.isnan(_df[y])]\n",
+    "        _df_15 = _df[_df.category.isin(cats_15_no_lo)]\n",
+    "        lst = _df_15[y][~np.isnan(_df[y])]\n",
     "        pos = 0.5 / _years * (j - _years / 2) + i\n",
     "        \n",
     "        outliers = len(lst[lst > ymax])\n",

--- a/assessment/sr15_2.4.2.2_electricity_generation_marker-scenarios.ipynb
+++ b/assessment/sr15_2.4.2.2_electricity_generation_marker-scenarios.ipynb
@@ -461,6 +461,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export timeseries data to `xlsx`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writer = pd.ExcelWriter('output/fig2.16_data_table.xlsx')\n",
+    "pyam.utils.write_sheet(writer, name, \n",
+    "                       pyam.filter_by_meta(df.timeseries(), df, category=None, marker=None, join_meta=True),\n",
+    "                       index=True)\n",
+    "writer.save()"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/assessment/sr15_2.4.2.2_electricity_generation_statistics.ipynb
+++ b/assessment/sr15_2.4.2.2_electricity_generation_statistics.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.2.2_electricity_generation_statistics.ipynb
+++ b/assessment/sr15_2.4.2.2_electricity_generation_statistics.ipynb
@@ -131,7 +131,7 @@
    "source": [
     "stats = pyam.Statistics(df=df,\n",
     "                        filters=[('all 1.5', {}),\n",
-    "                                 ('no/lo os 1.5', {'category': cats_15_no_lo}),\n",
+    "                                 ('no & lo os 1.5', {'category': cats_15_no_lo}),\n",
     "                                 ('hi os 1.5', {'category': ['1.5C high overshoot']})\n",
     "                                ], rows=True)"
    ]

--- a/assessment/sr15_2.4.2.3_ccs_deployment.ipynb
+++ b/assessment/sr15_2.4.2.3_ccs_deployment.ipynb
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set specifications for filter and plotting"
+    "## Set specifications for filter and plotting and initialize a data list"
    ]
   },
   {
@@ -168,6 +168,15 @@
     "    return {'categories': cats, 'column': 'category', 'years': range(2020, 2101, 10), 'add_marker': marker,\n",
     "            'ylabel': plot_ylabel.format(name),\n",
     "            'save': save_name.format(name if panel_label is None else '{}_{}'.format(panel_label, name), filetype)}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = []"
    ]
   },
   {
@@ -208,7 +217,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccs_bio = df.filter(variable='Primary Energy|Biomass|Modern|w/ CCS').timeseries()"
+    "ccs_bio = (\n",
+    "    pyam.filter_by_meta(\n",
+    "        df.filter(variable='Primary Energy|Biomass|Modern|w/ CCS')\n",
+    "        .timeseries(), **filter_args)\n",
+    ")"
    ]
   },
   {
@@ -218,9 +231,7 @@
    "outputs": [],
    "source": [
     "name = 'bioenergy'\n",
-    "fig = boxplot_by_cat(\n",
-    "    pyam.filter_by_meta(ccs_bio, **filter_args),\n",
-    "    **plotting_args(name, 'a'))"
+    "fig = boxplot_by_cat(ccs_bio, **plotting_args(name, 'a'))"
    ]
   },
   {
@@ -229,7 +240,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccs_coal = df.filter(variable='Primary Energy|Coal|w/ CCS').timeseries()"
+    "data.append(('Bioenergy with CCS', ccs_bio))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ccs_coal = (\n",
+    "    pyam.filter_by_meta(\n",
+    "        df.filter(variable='Primary Energy|Coal|w/ CCS')\n",
+    "        .timeseries(), **filter_args)\n",
+    ")"
    ]
   },
   {
@@ -239,9 +263,7 @@
    "outputs": [],
    "source": [
     "name = 'coal'\n",
-    "boxplot_by_cat(\n",
-    "    pyam.filter_by_meta(ccs_coal, **filter_args),\n",
-    "    **plotting_args(name, 'b'), legend=False)"
+    "boxplot_by_cat(ccs_coal, **plotting_args(name, 'b'), legend=False)"
    ]
   },
   {
@@ -250,8 +272,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccs_gas = df.filter(variable='Primary Energy|Gas|w/ CCS').timeseries()\n",
-    "ccs_gas.index = ccs_gas.index.droplevel([2, 3, 4])"
+    "data.append(('Coal with CCS', ccs_coal))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ccs_gas = (\n",
+    "    pyam.filter_by_meta(\n",
+    "        df.filter(variable='Primary Energy|Gas|w/ CCS')\n",
+    "        .timeseries(), **filter_args)\n",
+    ")"
    ]
   },
   {
@@ -261,9 +295,16 @@
    "outputs": [],
    "source": [
     "name = 'gas'\n",
-    "boxplot_by_cat(\n",
-    "    pyam.filter_by_meta(ccs_gas, **filter_args),\n",
-    "    **plotting_args(name, 'c'), legend=False)"
+    "boxplot_by_cat(ccs_gas, **plotting_args(name, 'c'), legend=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.append(('Gas with CCS', ccs_gas))"
    ]
   },
   {
@@ -283,7 +324,8 @@
     "    df.filter(variable='Carbon Sequestration|CCS')\n",
     "    .convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)})\n",
     "    .timeseries()\n",
-    ")"
+    ")\n",
+    "ccs.index = ccs.index.droplevel([2, 3, 4])"
    ]
   },
   {
@@ -293,8 +335,10 @@
    "outputs": [],
    "source": [
     "cum_ccs = pd.DataFrame()\n",
-    "for i in range(2020, 2100, 10):\n",
-    "    cum_ccs[i] = ccs.apply(pyam.cumulative, raw=False, axis=1, first_year=2020, last_year=i)"
+    "for i in range(2030, 2100, 10):\n",
+    "    cum_ccs[i] = ccs.apply(pyam.cumulative, raw=False, axis=1, first_year=2020, last_year=i)\n",
+    "\n",
+    "cum_ccs = pyam.filter_by_meta(cum_ccs, **filter_args)"
    ]
   },
   {
@@ -304,11 +348,39 @@
    "outputs": [],
    "source": [
     "boxplot_by_cat(\n",
-    "    pyam.filter_by_meta(cum_ccs, **filter_args),\n",
-    "    categories=cats, column='category', years=range(2020, 2100, 10),\n",
+    "    cum_ccs,\n",
+    "    categories=cats, column='category', years=range(2030, 2100, 10),\n",
     "    ylabel='cumulative CO2 stored (Gt)',\n",
     "    save=save_name.format('d_cumulative_ccs', figure_format),\n",
     "    ymax=2050, add_marker=marker, legend=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.append(('Cumulative CCS', cum_ccs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export timeseries data to `xlsx`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writer = pd.ExcelWriter('output/fig2.17_data_table.xlsx')\n",
+    "for (name, _df) in data:\n",
+    "    pyam.utils.write_sheet(writer, name, _df, index=True)\n",
+    "writer.save()"
    ]
   },
   {

--- a/assessment/sr15_2.4.2.3_ccs_deployment.ipynb
+++ b/assessment/sr15_2.4.2.3_ccs_deployment.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.4.4_afolu_emissions.ipynb
+++ b/assessment/sr15_2.4.4_afolu_emissions.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_2.5_carbon_price_analysis.ipynb
+++ b/assessment/sr15_2.5_carbon_price_analysis.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_4.2_sectoral_indicators.ipynb
+++ b/assessment/sr15_4.2_sectoral_indicators.ipynb
@@ -12,7 +12,7 @@
     "# Indicators of the pace of transformation <br /> in 1.5°C pathways and selected sectoral studies\n",
     "\n",
     "This notebook computes indicators of sectoral transformation for comparison to specialized studies\n",
-    "in Chapter 4 of the IPCC's _\"Special Report on Global Warming of 1.5°C\"_.\n",
+    "in Chapter 4 (**Table 4.1**) of the IPCC's _\"Special Report on Global Warming of 1.5°C\"_.\n",
     "\n",
     "The scenario data used in this analysis can be accessed and downloaded at [https://data.ene.iiasa.ac.at/iamc-1.5c-explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer)."
    ]

--- a/assessment/sr15_4.2_sectoral_indicators.ipynb
+++ b/assessment/sr15_4.2_sectoral_indicators.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/assessment/sr15_4.2_sectoral_indicators.ipynb
+++ b/assessment/sr15_4.2_sectoral_indicators.ipynb
@@ -359,7 +359,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "summary.to_excel('output/sr15_table_4.2_sectoral_indicators.xlsx')"
+    "summary.to_excel('output/table_4.2_sectoral_indicators.xlsx')"
    ]
   },
   {

--- a/data/README.md
+++ b/data/README.md
@@ -9,7 +9,7 @@ The data must be saved as an IAMC-style `csv` or `xlsx` file.
 The scenario ensemble used for this assessment is available for download
 at [data.ene.iiasa.ac.at/iamc-1.5c-explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer).
 
-The scenario data is licensed under a derivative of the Creative Commons CC-BY 4.0 License.
+The scenario data is released under a custom license.
 If appropriate reference is made to the data source, it is permitted to use
 the data for scientific research and science communication.
 However, redistribution of substantial portions of the data is restricted.

--- a/further_analysis/iamc15_energy_intensity.ipynb
+++ b/further_analysis/iamc15_energy_intensity.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {

--- a/further_analysis/iamc15_gdp_per_capita.ipynb
+++ b/further_analysis/iamc15_gdp_per_capita.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.xlsx')"
+    "sr1p5 = pyam.IamDataFrame(data='../data/iamc15_scenario_data_world_r1.1.xlsx')"
    ]
   },
   {


### PR DESCRIPTION
This PR implements a number of changes that were made as part of the tricklebacks following the IPCC plenary in October 2018 to ensure consistency of the assessment notebooks with the published version of the [SR15](http://www.ipcc.ch/report/sr15/).

All notebooks now use **release 1.1** of the [IAMC 1.5C Scenario Explorer and Data](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer).

closes #1 
closes #2 
closes #3 
closes #4 
closes #5 
closes #7
closes #9
closes #10 
closes #12