### PR TITLE
Add figure panels for SPM 3b (contributions to global net CO2)

### DIFF
--- a/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
+++ b/assessment/spm_sr15_figure_3b_illustrative_pathways.ipynb
@@ -12,7 +12,7 @@
     "# Characteristics of four illustrative model pathways\n",
     "## Figure 3b of the *Summary for Policymakers*\n",
     "\n",
-    "This notebook derives the indicators for the table in Figure 3b in the Summary for Policymakers\n",
+    "This notebook derives the figure panels and indicators for the table in Figure 3b in the Summary for Policymakers\n",
     "of the IPCC's _\"Special Report on Global Warming of 1.5°C\"_.\n",
     "\n",
     "The scenario data used in this analysis can be accessed and downloaded at [https://data.ene.iiasa.ac.at/iamc-1.5c-explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer)."
@@ -117,6 +117,244 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Global carbon dioxide emissions in four illustrative pathways\n",
+    "\n",
+    "Figure SPM3b shows the contribution to CO2 emissions and removal by three categories in the four illustrative pathways.\n",
+    "\n",
+    "This illustration does not use the emissions timeseries as reported by the models. This is because the variable `Emissions|CO2|Energy and Industrial Processes` represents net emissions, incorporating carbon dioxide removal in this sector.\n",
+    "\n",
+    "The steps below compute the gross emissions. The long variable names are mapped to short variables for easier readibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afolu_var = 'Emissions|CO2|AFOLU'\n",
+    "ene_ind_var = 'Emissions|CO2|Energy and Industrial Processes'\n",
+    "beccs_var ='Carbon Sequestration|CCS|Biomass'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We downselect the entire data to the four illustrative pathways (`marker` scenarios) and the three variables of interest. For consistency with the figure in the SPM, the units are converted to Gt CO2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pw = df.filter(marker=marker, variable=[afolu_var, ene_ind_var, beccs_var],\n",
+    "               year=range(2010, 2101, 10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pw.convert_unit({'Mt CO2/yr': ('Gt CO2/yr', 0.001)}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a first step, we extract the timeseries for the AFOLU emissions and rename the variable for brevity. This data will be used as is in this figure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afolu = (\n",
+    "    pw.filter(variable=afolu_var)\n",
+    "    .rename(variable={afolu_var: 'AFOLU'})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The energy-and-industry and BECCS timeseries data needs some processing. It is first separated into two distinct dataframes, and the BECCS variable is renamed for brevity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ene_ind = pw.filter(variable=ene_ind_var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beccs = (\n",
+    "    pw.filter(variable=beccs_var)\n",
+    "   .rename(variable={beccs_var: 'BECCS'})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The variable `Carbon Sequestration|CCS|Biomass` reports removed carbon dioxide as positive values. For use in this figure, the sign needs to be reversed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beccs.data.value = - beccs.data.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `LED` marker scenario does not use any BECCS by assumption of the scenario design. For this reason, the variable `Carbon Sequestration|CCS|Biomass` was not defined when the MESSAGE team submitted the scenario results to the IAMC 1.5°C Scenario Data ensemble.\n",
+    "\n",
+    "For easier computation, we add this data series manually here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "years = beccs.timeseries().columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beccs.append(\n",
+    "    pyam.IamDataFrame(\n",
+    "        pd.DataFrame([0] * len(years), index=years).T,\n",
+    "        model='MESSAGEix-GLOBIOM 1.0', scenario='LowEnergyDemand',\n",
+    "        region='World', variable='BECCS', unit='Gt CO2/yr'),\n",
+    "    inplace=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a third step, we compute the difference between net CO2 emissions from the energy sector & industry and BECCS to obtain gross CO2 emissions in that sector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_value(df):\n",
+    "    cols = ['model', 'scenario', 'region', 'year', 'unit']\n",
+    "    return df.data.set_index(cols)['value']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diff = get_value(ene_ind) - get_value(beccs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ene_ind_gross = pyam.IamDataFrame(diff, variable='Fossil fuel and industry')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now combine the three contribution dataframes into one joint dataframe for plotting. Because the `beccs` IamDataFrame was partially altered, concatenating directly causes an issue, so we remove all `meta` columns from that dataframe beforehand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beccs.meta = beccs.meta.drop(columns=beccs.meta.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "co2 = pyam.concat([ene_ind_gross, afolu, beccs])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now proceed to plot the four illustrative pathways."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 4, figsize=(14, 4), sharey=True)\n",
+    "\n",
+    "for i, m in enumerate(['LED', 'S1', 'S2', 'S5']):\n",
+    "    co2.filter(marker=m).stack_plot(ax=ax[i], total=True, legend=False)\n",
+    "    ax[i].title.set_text(m)\n",
+    "\n",
+    "ax[3].legend(loc=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Collecting indicators across illustrative pathways\n",
+    "\n",
+    "### Initialize a `pyam.Statistics` instance"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -125,13 +363,6 @@
     "base_year = 2010\n",
     "compare_years = [2030, 2050]\n",
     "years = [base_year] + compare_years"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Initialize a `pyam.Statistics` instance"
    ]
   },
   {
@@ -148,8 +379,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Collecting indicators\n",
-    "\n",
     "### CO2 and Kyoto GHG emissions reductions"
    ]
   },


### PR DESCRIPTION
This PR extends the notebook to generate the statistical indicators used in SR15 SPM3b with four stack-plot panels of CO2 contributions in the four illustrative pathways.

Closes #25 